### PR TITLE
make the image description area semi-transparent again

### DIFF
--- a/app/javascript/styles/beachcity.scss
+++ b/app/javascript/styles/beachcity.scss
@@ -28,6 +28,10 @@ $ui-highlight-color: #C4385F;
     background-color: #FFFFD9 !important;
 }
 
+.compose-form .compose-form__upload-description textarea {
+    background-color: transparent !important;
+}
+
 .compose-form__buttons-wrapper {
     background-color: #FED6B8 !important;
 }


### PR DESCRIPTION
This was causing the text input for descriptions to be unreadable