### PR TITLE
Use user-specified font instead of hardcoded list

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -19,18 +19,7 @@ body {
   -webkit-tap-highlight-color: transparent;
 
   &.system-font {
-    // system-ui => standard property (Chrome/Android WebView 56+, Opera 43+, Safari 11+)
-    // -apple-system => Safari <11 specific
-    // BlinkMacSystemFont => Chrome <56 on macOS specific
-    // Segoe UI => Windows 7/8/10
-    // Oxygen => KDE
-    // Ubuntu => Unity/Ubuntu
-    // Cantarell => GNOME
-    // Fira Sans => Firefox OS
-    // Droid Sans => Older Androids (<4.0)
-    // Helvetica Neue => Older macOS <10.11
-    // $font-sans-serif => web-font (Roboto) fallback and newer Androids (>=4.0)
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", $font-sans-serif, sans-serif;
+    font-family: sans-serif;
   }
 
   &.app-body {

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -106,7 +106,7 @@ en:
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
-        setting_system_font_ui: Use system's default font
+        setting_system_font_ui: Use browser's default font
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity

--- a/config/locales/simple_form.en_GB.yml
+++ b/config/locales/simple_form.en_GB.yml
@@ -104,7 +104,7 @@ en_GB:
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
-        setting_system_font_ui: Use system's default font
+        setting_system_font_ui: Use browser's default font
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity

--- a/config/locales/simple_form.no.yml
+++ b/config/locales/simple_form.no.yml
@@ -38,7 +38,7 @@
         setting_delete_modal: Vis bekreftelse før du sletter en tut
         setting_noindex: Ikke delta i søkemotorsindeksering
         setting_reduce_motion: Reduser bevegelser i animasjoner
-        setting_system_font_ui: Bruk systemets standardfont
+        setting_system_font_ui: Bruk nettleserens standardfont
         setting_theme: Sidens tema
         setting_unfollow_modal: Vis bekreftelse før du slutter å følge noen
         severity: Alvorlighetsgrad

--- a/config/locales/simple_form.sv.yml
+++ b/config/locales/simple_form.sv.yml
@@ -64,7 +64,7 @@ sv:
         setting_hide_network: Göm ditt nätverk
         setting_noindex: Uteslutning av sökmotorindexering
         setting_reduce_motion: Minska rörelser i animationer
-        setting_system_font_ui: Använd systemets standardfont
+        setting_system_font_ui: Använd webbläsarens standardfont
         setting_theme: Sidans tema
         setting_unfollow_modal: Visa bekräftelse innan du slutar följa någon
         severity: Strikthet


### PR DESCRIPTION
Replace list with "system fonts" from a handful of operating systems with
the default browser font, which is much easier for the user to change.

For some users, if they are using an OS represented in the list, this might
be the same font, but for those who have explicitly specified a different
font, Mastodon will now use that instead.