### PR TITLE
DB Migration for Doodle Button Setting

### DIFF
--- a/BC_CHANGELOG.md
+++ b/BC_CHANGELOG.md
@@ -7,6 +7,7 @@ All changes to Beach City beyond the vanilla Beach City code will be documented 
 ## Added
 - Simplified versions of existing themes with a single column.
 - Added an opt-in setting for the doodle pad, under a new "mods" settings section
+- Made sure existing users have doodles enabled by default
 
 ## Changed
 - Changed Drawing tool icon to a paint brush

--- a/db/migrate/20190524221356_doodles_enabled_for_existing_users.rb
+++ b/db/migrate/20190524221356_doodles_enabled_for_existing_users.rb
@@ -1,0 +1,12 @@
+class DoodlesEnabledForExistingUsers < ActiveRecord::Migration[5.2]
+  def self.up
+    User.find_each do | user |
+      user.settings['enable_doodle'] = true;
+      user.save
+    end
+  end
+  
+  def self.down
+    execute "DELETE FROM settings WHERE var = 'enable_doodle'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_19_130537) do
+ActiveRecord::Schema.define(version: 2019_05_24_221356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Added a migration that will opt all current users in to enabling the doodle button when run, and remove all existing doodle button preferences when rolled back.